### PR TITLE
Add support for libvirt provider and Whamcloud mirror

### DIFF
--- a/centos_7-8_lustre_2-12-5_ldiskfs+zfs/Vagrantfile
+++ b/centos_7-8_lustre_2-12-5_ldiskfs+zfs/Vagrantfile
@@ -109,19 +109,31 @@ echo "options lnet networks=tcp0(eth1)" > /etc/modprobe.d/lnet.conf
 SCRIPT
 
 $configure_lustre_server_mgs_mds = <<-SCRIPT
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
 modprobe -v lnet
 modprobe -v lustre
 mkdir /mnt/mdt
-mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/sdb
-mount -t lustre /dev/sdb /mnt/mdt
+mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/${disk_type}b
+mount -t lustre /dev/${disk_type}b /mnt/mdt
 SCRIPT
 
 $configure_lustre_server_oss_zfs = <<-SCRIPT
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
 modprobe -v lnet
 modprobe -v lustre
 modprobe -v zfs
-zpool create ostpool0 /dev/sdb
-zpool create ostpool1 /dev/sdc
+zpool create ostpool0 /dev/${disk_type}b
+zpool create ostpool1 /dev/${disk_type}c
 mkfs.lustre --backfstype=zfs --ost --fsname phoenix --index 0 --mgsnode mxs@tcp0 ostpool0/ost0
 mkfs.lustre --backfstype=zfs --ost --fsname phoenix --index 1 --mgsnode mxs@tcp0 ostpool1/ost1
 mkdir -p /lustre/phoenix/ost0
@@ -140,6 +152,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 512
     v.cpus = 2
   end
+  config.vm.provider :libvirt
+
   config.vm.box = "centos/7"
   config.vm.box_version = "2004.01" # CentOS 7.8.2003
   config.vm.box_check_update = false
@@ -149,7 +163,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "mxs" do |mxs|
     mxs.vm.hostname = "mxs"
     mxs.vm.network "private_network", ip: "192.168.10.10"
-    mxs.vm.disk :disk, size: "10GB", name: "disk_for_lustre"
+    mxs.vm.provider :virtualbox do |vbox|
+      vbox.disk :disk, size: "10GB", name: "disk_for_lustre"
+    end
+    mxs.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     mxs.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     mxs.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     mxs.vm.provision "shell", name: "remove_packages_kernel_tools", inline: $remove_packages_kernel_tools
@@ -165,8 +187,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "oss" do |oss|
     oss.vm.hostname = "oss"
     oss.vm.network "private_network", ip: "192.168.10.20"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    oss.vm.provider :virtualbox do |vbox|
+      oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
+      oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    end
+    oss.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_1.img',
+                      :size => '10G',
+                      :type => 'raw'
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_2.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     oss.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     oss.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     oss.vm.provision "shell", name: "remove_packages_kernel_tools", inline: $remove_packages_kernel_tools

--- a/centos_7-8_lustre_2-12-5_ldiskfs/Vagrantfile
+++ b/centos_7-8_lustre_2-12-5_ldiskfs/Vagrantfile
@@ -84,20 +84,32 @@ echo "options lnet networks=tcp0(eth1)" > /etc/modprobe.d/lnet.conf
 SCRIPT
 
 $configure_lustre_server_mgs_mds = <<-SCRIPT
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
 mkdir /mnt/mdt
-mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/sdb
+mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/${disk_type}b
 # Mounting Lustre loads lnet module implicitly.
-mount -t lustre /dev/sdb /mnt/mdt
+mount -t lustre /dev/${disk_type}b /mnt/mdt
 SCRIPT
 
 $configure_lustre_server_oss_ldiskfs = <<-SCRIPT
-mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgsnode=mxs@tcp0 --ost --index=1 /dev/sdb
-mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgsnode=mxs@tcp0 --ost --index=2 /dev/sdc
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
+mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgsnode=mxs@tcp0 --ost --index=1 /dev/${disk_type}b
+mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgsnode=mxs@tcp0 --ost --index=2 /dev/${disk_type}c
 mkdir /mnt/ost1
 mkdir /mnt/ost2
 # Mounting OSTs loads lnet module implicitly.
-mount.lustre /dev/sdb /mnt/ost1
-mount.lustre /dev/sdc /mnt/ost2
+mount.lustre /dev/${disk_type}b /mnt/ost1
+mount.lustre /dev/${disk_type}c /mnt/ost2
 SCRIPT
 
 $configure_lustre_client = <<-SCRIPT
@@ -121,7 +133,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "mxs" do |mxs|
     mxs.vm.hostname = "mxs"
     mxs.vm.network "private_network", ip: "192.168.10.10"
-    mxs.vm.disk :disk, size: "10GB", name: "disk_for_lustre"
+    mxs.vm.provider :virtualbox do |vbox|
+      vbox.disk :disk, size: "10GB", name: "disk_for_lustre"
+    end
+    mxs.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     mxs.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     mxs.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     mxs.vm.provision "shell", name: "install_packages_misc", inline: $install_packages_server_misc
@@ -134,8 +154,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "oss" do |oss|
     oss.vm.hostname = "oss"
     oss.vm.network "private_network", ip: "192.168.10.20"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    oss.vm.provider :virtualbox do |vbox|
+      vbox.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
+      vbox.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    end
+    oss.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_1.img',
+                      :size => '10G',
+                      :type => 'raw'
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_2.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     oss.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     oss.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     oss.vm.provision "shell", name: "install_packages_misc", inline: $install_packages_server_misc

--- a/centos_stream_8_lustre_2-14/Vagrantfile
+++ b/centos_stream_8_lustre_2-14/Vagrantfile
@@ -107,19 +107,31 @@ echo "options lnet networks=tcp0(eth1)" > /etc/modprobe.d/lnet.conf
 SCRIPT
 
 $configure_lustre_server_mgs_mds = <<-SCRIPT
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
 modprobe -v lnet
 modprobe -v lustre
 mkdir /mnt/mdt
-mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/sdb
-mount -t lustre /dev/sdb /mnt/mdt
+mkfs.lustre --backfstype=ldiskfs --fsname=phoenix --mgs --mdt --index=0 /dev/${disk_type}b
+mount -t lustre /dev/${disk_type}b /mnt/mdt
 SCRIPT
 
 $configure_lustre_server_oss_zfs = <<-SCRIPT
+disk_types="sd vd UNKNOWN"
+for disk_type in $disk_types; do
+  if [ -b "/dev/${disk_type}b" ]; then
+    break
+  fi
+done
 modprobe -v lnet
 modprobe -v lustre
 modprobe -v zfs
-zpool create ostpool0 /dev/sdb
-zpool create ostpool1 /dev/sdc
+zpool create ostpool0 /dev/${disk_type}b
+zpool create ostpool1 /dev/${disk_type}c
 mkfs.lustre --backfstype=zfs --ost --fsname phoenix --index 0 --mgsnode mxs@tcp0 ostpool0/ost0
 mkfs.lustre --backfstype=zfs --ost --fsname phoenix --index 1 --mgsnode mxs@tcp0 ostpool1/ost1
 mkdir -p /lustre/phoenix/ost0
@@ -138,6 +150,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 512
     v.cpus = 2
   end
+  config.vm.provider :libvirt
   config.vm.box = "centos/stream8"
   config.vm.box_version = "20210210.0"
   config.vm.box_check_update = false
@@ -147,7 +160,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "mxs" do |mxs|
     mxs.vm.hostname = "mxs"
     mxs.vm.network "private_network", ip: "192.168.10.10"
-    mxs.vm.disk :disk, size: "10GB", name: "disk_for_lustre"
+    mxs.vm.provider :virtualbox do |vbox|
+      vbox.disk :disk, size: "10GB", name: "disk_for_lustre"
+    end
+    mxs.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     mxs.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     mxs.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     mxs.vm.provision "shell", name: "install_perl", inline: "yum install -y perl"
@@ -163,8 +184,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define  "oss" do |oss|
     oss.vm.hostname = "oss"
     oss.vm.network "private_network", ip: "192.168.10.20"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
-    oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    oss.vm.provider :virtualbox do |vbox|
+      oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_1"
+      oss.vm.disk :disk, size: "10GB", name: "disk_for_lustre_ost_2"
+    end
+    oss.vm.provider :libvirt do |libvirt|
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_1.img',
+                      :size => '10G',
+                      :type => 'raw'
+      libvirt.storage :file,
+                      :path => 'disk_for_lustre_ost_2.img',
+                      :size => '10G',
+                      :type => 'raw'
+    end
     oss.vm.provision "shell", name: "create_repo_e2fsprogs", inline: $create_repo_e2fsprogs
     oss.vm.provision "shell", name: "create_repo_lustre_server", inline: $create_repo_lustre_server
     oss.vm.provision "shell", name: "install_perl", inline: "yum install -y perl"


### PR DESCRIPTION
Hi Gabriele,

Not sure if you're expecting pull requests for this, but why not?  :smile: 

The main 2 things here are:

- Add support for the Vagrant `libvirt` provider
  This is harder than it should be, primarily because of different device names.  I spent a long time trying to find a better way than this, but this is the only way I could make it work.  I think it would probably work with an environment variable for the disk prefix, and this might require a function to set the inline provider script just before using it.  However, that is very ugly!  Note that *I have not actually tested this with `virtualbox`*.  It should work - the only place it might fail would be if setting `ENV["VAGRANT_EXPERIMENTAL"]` does not work as expected.  This could be moved back to the top because it doesn't affect the `libvirt` provider.
- Allow a Whamcloud mirror.  Installing directly from the Whamcloud site sometimes stalls.  Using a local mirror on the host machine is flawless.

What do you think?

Thanks...

--martin